### PR TITLE
Enforce unique date (1 entry per day)

### DIFF
--- a/healthy_habits_tracker/app.py
+++ b/healthy_habits_tracker/app.py
@@ -1,6 +1,10 @@
 from flask import Flask
-from flask_sqlalchemy import SQLAlchemy
+from flask_sqlalchemy import SQLAlchemy # type: ignore
 from pathlib import Path
+
+#  ADDED (needed for graceful duplicate handling)
+from sqlalchemy.exc import IntegrityError
+from flask import request  # to read form data (POST)
 
 APP_NAME = "Healthy Habits Tracker"
 APP_VERSION = "1.0.0"
@@ -21,7 +25,7 @@ db = SQLAlchemy(app)
 
 class HabitEntry(db.Model):
     id = db.Column(db.Integer, primary_key=True)
-    date = db.Column(db.Date, unique=True, nullable=False)
+    date = db.Column(db.Date, unique=True, nullable=False)  #  already unique
     gym = db.Column(db.Boolean, default=False)
     water = db.Column(db.Integer, default=0)
     healthy_food = db.Column(db.Boolean, default=False)
@@ -34,6 +38,76 @@ with app.app_context():
 @app.get("/")
 def home():
     return "Flask is running! DB ready! Check the instance/app.db file."
+
+
+@app.route("/log", methods=["GET", "POST"])
+def log_habits():
+    if request.method == "GET":
+        
+        return """
+        <h1>Log Habits</h1>
+        <form method="POST">
+            <label>Date:</label>
+            <input type="date" name="date" required><br><br>
+
+            <label>Gym:</label>
+            <input type="checkbox" name="gym"><br><br>
+
+            <label>Water (cups):</label>
+            <input type="number" name="water" min="0" value="0"><br><br>
+
+            <label>Healthy Food:</label>
+            <input type="checkbox" name="healthy_food"><br><br>
+
+            <label>Notes:</label><br>
+            <textarea name="notes" maxlength="300"></textarea><br><br>
+
+            <button type="submit">Save</button>
+        </form>
+        <p><a href="/">Back home</a></p>
+        """
+
+    
+    date_str = request.form.get("date", "").strip()
+    if not date_str:
+        return "Date is required. Please go back and select a date.", 400
+
+   
+    gym = "gym" in request.form
+    healthy_food = "healthy_food" in request.form
+
+    
+    water_raw = request.form.get("water", "0").strip()
+    try:
+        water = int(water_raw) if water_raw else 0
+    except ValueError:
+        water = 0
+
+    notes = request.form.get("notes", "").strip()
+
+   
+    entry = HabitEntry(
+        date=date_str, 
+        gym=gym,
+        water=water,
+        healthy_food=healthy_food,
+        notes=notes
+    )
+
+    db.session.add(entry)
+
+   
+    try:
+        db.session.commit()
+        return f"Saved entry for {date_str}! ✅ <br><a href='/log'>Log another</a>"
+    except IntegrityError:
+        db.session.rollback()
+        return (
+            f"⚠️ An entry for <b>{date_str}</b> already exists. "
+            f"Please choose another date or edit the existing one. "
+            f"<br><a href='/log'>Back to form</a>"
+        ), 409
+
 
 if __name__ == "__main__":
     app.run(debug=True)


### PR DESCRIPTION
Title: ISSUE 6 — Enforce unique date (1 entry per day) + graceful duplicate handling

Description
Implement the “one entry per day” rule in the Flask app by enforcing a unique date and handling duplicate date inserts without crashing.

What was implemented

Verified/enforced that the HabitEntry.date column is unique and required:

date = db.Column(db.Date, unique=True, nullable=False)
Added a new route: /log with GET + POST:

GET: Displays a simple HTML form (no templates yet) to log habits.
POST: Reads form data and attempts to create a HabitEntry in the database.
Added graceful duplicate error handling using SQLAlchemy:

Imported IntegrityError from sqlalchemy.exc

Wrapped db.session.commit() in try/except

On duplicate date:

Calls db.session.rollback()
Returns a friendly message explaining that an entry for that date already exists
Returns HTTP status 409 (Conflict) instead of crashing
Added basic validation:

If date is missing, returns a helpful error message (400)
Safe parsing for numeric water input (defaults to 0 if invalid)
Files changed

healthy_habits_tracker/app.py
How to test (manual)

Start the app:

flask --app healthy_habits_tracker/app.py run
Open:

http://127.0.0.1:5000/log
Submit a new entry with a date (example: 2026-01-27) → should save successfully 

Submit another entry with the same date → should not crash and should show a friendly duplicate message 

Done when

Duplicate inserts do not crash the app.
Duplicate date submissions show a friendly message and the app remains usable.
Date uniqueness is enforced at the database level via unique=True.